### PR TITLE
Close socket in case of NegativeArraySizeException in receiveConnection

### DIFF
--- a/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
+++ b/src/java/main/org/apache/zookeeper/server/quorum/QuorumCnxManager.java
@@ -259,6 +259,10 @@ public class QuorumCnxManager {
             closeSocket(sock);
             LOG.warn("Exception reading or writing challenge: " + e.toString());
             return false;
+        } catch (RuntimeException e) {
+            closeSocket(sock);
+            LOG.warn("Exception reading or writing challenge: " + e.toString());
+            return false;
         }
         
         //If wins the challenge, then close the new connection.


### PR DESCRIPTION
During vuln scan socket used for election is blocked by CLOSE_WAIT connection
due to a missing socket close in case of NegativeArraySizeException